### PR TITLE
Added Githubflow as workflow for branches

### DIFF
--- a/docs/guidlines/git.md
+++ b/docs/guidlines/git.md
@@ -14,12 +14,13 @@ After a PR is merged it should be deleted.
 
 **In general:**
 Use feature-branches as much as possible. 
-The pattern is `{fix, feature or refactor}/{Jira item number}/{title}`
-* {fix, feature or refactor} prefixing a branch makes it easier to search and filter among branches.
+The pattern is `{epic or type of branch (fix,feature or refactor)}/{Jira item number}/{title}`
+* {epic or type of branch (fix,feature or refactor} prefixing a branch makes it easier to search and filter among branches.
 * {Jira item number} makes the branch and PR be integrated with Jira.
 * {title} use short title as possible, whitespace should be replaced with a dash.
 
-* `feature/fa-313/xsl-embedded-resource`
+* `paymentflow/fa-313/xsl-embedded-resource` with epic
+* `feature/fa-338/free-priority-boarding` with type of branch
 * `master` has the code for the latest release to staging.
 * `dev` has the code that is being worked on but not yet released. This is the branch into which devs normally submit pull requests and merge changes into.
 

--- a/docs/guidlines/git.md
+++ b/docs/guidlines/git.md
@@ -8,7 +8,11 @@ In general a PR should be signed off (using the :shipit: `:shipit:` emoticon) by
 
 ### Branch strategy
 
+* Using the [Github workflow] (https://guides.github.com/introduction/flow/)
+
 In general:
+Use feature-branches as much as possible. When creating a branch it should start with the item number. 
+* `PRJ-1 **title**` this makes the branch and later the PR to be connected to the item in Jira.
 
 * `master` has the code for the latest release to staging.
 * `dev` has the code that is being worked on but not yet released. This is the branch into which devs normally submit pull requests and merge changes into.

--- a/docs/guidlines/git.md
+++ b/docs/guidlines/git.md
@@ -6,14 +6,20 @@ The advantages are numerous: improving code quality, more visibility on changes 
 
 In general a PR should be signed off (using the :shipit: `:shipit:` emoticon) by any developer. As long it's not your self signing it off.
 
+After a PR is merged it should be deleted.
+
 ### Branch strategy
 
 * Using the [Github workflow] (https://guides.github.com/introduction/flow/)
 
-In general:
-Use feature-branches as much as possible. When creating a branch it should start with the item number. 
-* `PRJ-1 **title**` this makes the branch and later the PR to be connected to the item in Jira.
+**In general:**
+Use feature-branches as much as possible. 
+The pattern is `{fix, feature or refactor}/{Jira item number}/{title}`
+* {fix, feature or refactor} prefixing a branch makes it easier to search and filter among branches.
+* {Jira item number} makes the branch and PR be integrated with Jira.
+* {title} use short title as possible, whitespace should be replaced with a dash.
 
+* `feature/fa-313/xsl-embedded-resource`
 * `master` has the code for the latest release to staging.
 * `dev` has the code that is being worked on but not yet released. This is the branch into which devs normally submit pull requests and merge changes into.
 


### PR DESCRIPTION
Tycker att vi kan använda oss i större utsträckning av "[GitHub flow](https://guides.github.com/introduction/flow/)".
Kortfattat, vi har _master_ & _dev_ som stående branches. 
När vi börjar på någon ny feature, eller en längre bugfix, så skapar vi en branch för att sedan merga in till dev igenom en pull request.
Om branchen börjar med Jira itemnumret så kopplas den branchen och commiterna ihop i Jira.